### PR TITLE
Make parseResponse handle PDFs right

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -491,7 +491,7 @@ class XeroOAuth
         if (isset($format)) {
             switch ($format) {
                 case "pdf":
-                    $theResponse = json_decode($response);
+                    $theResponse = $response;
                     break;
                 case "json":
                     $theResponse = json_decode($response);


### PR DESCRIPTION
The parseResponse function was trying to json_decode() returned PDFs, which ended up returning NULL. Removed the function call and it magically works.
