### PR TITLE
Fix path to bundled OAuthSimple

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -2,7 +2,7 @@
 // Allow OAuthSimple to be autoloaded instead of always including directly.
 // The class_exists() call fires the autoloader.
 if (! class_exists ( 'OAuthSimple' )) {
-	require 'lib/OAuthSimple.php';
+	require_once __DIR__ . DIRECTORY_SEPARATOR . 'OAuthSimple.php';
 }
 
 /**


### PR DESCRIPTION
OAuthSimple include is broken (unless specifically added to include_path which won't be the default setup on users' systems). It is better to include the absolute path of the bundled OAuthSimple.php within the lib directory (next to XeroOAuth.php).
