### PR TITLE
Trim the XML content before performing request

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -441,8 +441,10 @@ class XeroOAuth {
 			$this->headers ['If-Modified-Since'] = $params ['If-Modified-Since'];
 		}
 		
-		if ($xml !== "")
+		if ($xml !== "") {
+			$xml = trim($xml);
 			$this->xml = $xml;
+		}
 		
 		if ($method == "POST")
 			$params ['xml'] = $xml;


### PR DESCRIPTION
This prevents any issues with PUT requests where the XML body was encoded with safe_encode
and the whitespace caused the request to fail.
