### PR TITLE
Update Private app type access token and secret

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -45,6 +45,11 @@ $signatures = array(
     'payroll_version'=> '1.0',
 );
 
+if (XRO_APP_TYPE=="Private") {
+  $signatures['access_token'] = $signatures['consumer_key'];
+  $signatures['access_token_secret'] = $signatures['shared_secret'];
+}
+
 if (XRO_APP_TYPE=="Private"||XRO_APP_TYPE=="Partner") {
     $signatures['rsa_private_key']= BASE_PATH . '/certs/privatekey.pem';
     $signatures['rsa_public_key']= BASE_PATH . '/certs/publickey.cer';


### PR DESCRIPTION
If an application is of type Private, then the access token and secret need to be the same as the consumer key and secret.

This is inline with Xero documentation. Including this change in _config.php cuts out a step for developers.
![screen shot 2014-05-17 at 6 44 21 pm](https://cloud.githubusercontent.com/assets/4101096/3004677/6d4ecbaa-ddb0-11e3-9cd4-05819a2f7788.png)
