### PR TITLE
Don't overwrite user config with defaults

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -87,7 +87,7 @@ class XeroOAuth {
 				'curl_verbose' => true 
 		);
 		
-		$this->config = array_merge ( $config, $this->_xero_defaults, $this->_xero_consumer_options, $this->_xero_curl_options );
+		$this->config = array_merge ( $this->_xero_defaults, $this->_xero_consumer_options, $this->_xero_curl_options, $config );
 	}
 	
 	/**


### PR DESCRIPTION
It doesn't really make sense to me to overwrite the passed config with defaults. Shouldn't it be the other way round as they are called 'defaults'? Would be useful to change the curl timeout for instance. I'm submitting a month's invoices in one call so it's timing out too early.