### PR TITLE
Fix issue with PDF attachments

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -301,12 +301,23 @@ class XeroOAuth {
 				break;
 			case 'PUT' :
 				$fh = tmpfile();
-				if ($this->format == "file") {
-					$put_body = $this->xml;
-				} else {
-					$put_body = $this->safe_encode ( $this->xml );
-					$this->headers ['Content-Type'] = 'application/x-www-form-urlencoded';
-				}
+				switch ($this->format) {
+					case "file" :
+						$put_body = $this->xml;
+						break;
+                                	case "pdf" :
+						$put_body = $this->xml;
+                                        	$this->headers ['Content-Type'] = 'application/pdf';
+                                        	break;
+                                	case "json" :
+						$put_body = $this->xml;
+                                        	$this->headers ['Content-Type'] = 'application/json';
+                                        	break;
+                                	default :
+                                        	$put_body = $this->safe_encode ( $this->xml );
+                                        	$this->headers ['Content-Type'] = 'application/x-www-form-urlencoded';
+                                        	break;
+                        	}
 				fwrite ( $fh, $put_body );
 				rewind ( $fh );
 				curl_setopt ( $c, CURLOPT_PUT, true );


### PR DESCRIPTION
There is an issue where the mime type of attachments it was always being set to application/x-www-form-urlencoded instead of what it should have been. See https://github.com/XeroAPI/XeroOAuth-PHP/issues/43#issuecomment-104675923